### PR TITLE
Make xinput parsing case-insensitive

### DIFF
--- a/inverse-scroll.sh
+++ b/inverse-scroll.sh
@@ -2,9 +2,9 @@
 
 # Get id of touchpad and the id of the field corresponding to
 # natural scrolling
-id=`xinput list | grep "Touchpad" | cut -d'=' -f2 | cut -d'[' -f1`
+id=`xinput list | grep -i "Touchpad" | cut -d'=' -f2 | cut -d'[' -f1`
 natural_scrolling_id=`xinput list-props $id | \
-                      grep "Natural Scrolling Enabled (" \
+                      grep -i "Natural Scrolling Enabled (" \
                       | cut -d'(' -f2 | cut -d')' -f1`
 
 # Set the property to true

--- a/tap-to-click.sh
+++ b/tap-to-click.sh
@@ -2,9 +2,9 @@
 
 # Get id of touchpad and the id of the field corresponding to
 # tapping to click
-id=`xinput list | grep "Touchpad" | cut -d'=' -f2 | cut -d'[' -f1`
+id=`xinput list | grep -i "Touchpad" | cut -d'=' -f2 | cut -d'[' -f1`
 tap_to_click_id=`xinput list-props $id | \
-                      grep "Tapping Enabled (" \
+                      grep -i "Tapping Enabled (" \
                       | cut -d'(' -f2 | cut -d')' -f1`
 
 # Set the property to true


### PR DESCRIPTION
Tank you for the useful scripts! This patch makes them work with touchpad names containing mixed case, e.g. `SynPS/2 Synaptics TouchPad`.